### PR TITLE
[Docs] Update install script example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is an Angular port for [react-content-loader](https://github.com/danilowoz/
 ### Yarn
 
 ```bash
-yarn add @netbasal/content-loader
+yarn add @netbasal/ngx-content-loader
 ```
 
 ## Usage


### PR DESCRIPTION
The install script was pointing to an old package name.

Now it's changed for a new one.