### PR TITLE
Fix `${window.location.href}`

### DIFF
--- a/projects/netbasal/ngx-content-loader/src/lib/content-loader.component.ts
+++ b/projects/netbasal/ngx-content-loader/src/lib/content-loader.component.ts
@@ -53,6 +53,7 @@ export class ContentLoaderComponent implements OnInit {
   }
 
   get clipStyle() {
-    return `url(${window.location.href}#${this.idClip})`;
+    const {origin, pathname} = window.location
+    return `${origin}${pathname}#${this.idClip})`;
   }
 }


### PR DESCRIPTION
Adding the current url to the `clipStyle` creates prevents the library from working when there is already a has in the url.

For example, if the current url is `http://mydomain.local/#/transactions`, the previous implementation would references both the current implementation would append the `idClip` to this url which causes the svgs to not load `http://mydomain.local/#/transactions#clipid`.

Another alternative and shorter solution  would be to do away with the location entirely i.e.
```
get clipStyle() {
  return `#${this.idClip})`;
}
```