### PR TITLE
fix: add baseUrl input instead of assuming what it should be

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ export class AppModule {}
 | Input               | Type    | Default           | Description                                       |
 | ------------------- | ------- | ----------------- | ------------------------------------------------- |
 | animate             | boolean | `true`            | `false` to render with no animation               |
+| baseUrl             | string  | ``                | Required if you're using `<base url="/" />` in your `<head/>`. Defaults to an empty string. This prop is commom used as: `<ContentLoader baseUrl={window.location.pathname} />` which will fill the svg attribute with the relative path. Related [#93](https://github.com/danilowoz/react-content-loader/issues/93).              
+   |
 | width               | number  | `400`             |                                                   |
 | height              | number  | `130`             |                                                   |
 | speed               | number  | `2`               |                                                   |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export class AppModule {}
 | Input               | Type    | Default           | Description                                       |
 | ------------------- | ------- | ----------------- | ------------------------------------------------- |
 | animate             | boolean | `true`            | `false` to render with no animation               |
-| baseUrl             | string  | ``                | Required if you're using `<base url="/" />` in your `<head/>`. Defaults to an empty string. This prop is commom used as: `<content-loader [baseUrl]=window.location.pathname />` which will fill the svg attribute with the relative path. Related [#93](https://github.com/danilowoz/react-content-loader/issues/93).              
+| baseUrl             | string  | ``                | Required if you're using `<base url="/" />` in your `<head/>`. Defaults to an empty string. This prop is commom used as: `<content-loader [baseUrl]="window.location.pathname"></content-loader>` which will fill the svg attribute with the relative path. Related [#93](https://github.com/danilowoz/react-content-loader/issues/93).              
    |
 | width               | number  | `400`             |                                                   |
 | height              | number  | `130`             |                                                   |

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export class AppModule {}
 | Input               | Type    | Default           | Description                                       |
 | ------------------- | ------- | ----------------- | ------------------------------------------------- |
 | animate             | boolean | `true`            | `false` to render with no animation               |
-| baseUrl             | string  | ``                | Required if you're using `<base url="/" />` in your `<head/>`. Defaults to an empty string. This prop is commom used as: `<ContentLoader baseUrl={window.location.pathname} />` which will fill the svg attribute with the relative path. Related [#93](https://github.com/danilowoz/react-content-loader/issues/93).              
+| baseUrl             | string  | ``                | Required if you're using `<base url="/" />` in your `<head/>`. Defaults to an empty string. This prop is commom used as: `<content-loader [baseUrl]=window.location.pathname />` which will fill the svg attribute with the relative path. Related [#93](https://github.com/danilowoz/react-content-loader/issues/93).              
    |
 | width               | number  | `400`             |                                                   |
 | height              | number  | `130`             |                                                   |

--- a/projects/netbasal/ngx-content-loader/src/lib/content-loader.component.ts
+++ b/projects/netbasal/ngx-content-loader/src/lib/content-loader.component.ts
@@ -14,6 +14,8 @@ export class ContentLoaderComponent implements OnInit {
   @Input()
   animate = true;
   @Input()
+  baseUrl = '';
+  @Input()
   width = 400;
   @Input()
   height = 130;
@@ -48,16 +50,11 @@ export class ContentLoaderComponent implements OnInit {
 
   get fillStyle() {
     return {
-      fill: `url(${this.urlBase}#${this.idGradient})`
+      fill: `url(${this.baseUrl}#${this.idGradient})`
     };
   }
 
   get clipStyle() {
-    return `url(${this.urlBase}#${this.idClip})`;
-  }
-  
-  get urlBase() {
-    const {origin, pathname} = window.location;
-    return `${origin}${pathname}`;
+    return `url(${this.baseUrl}#${this.idClip})`;
   }
 }


### PR DESCRIPTION
this mimics the change set here:
https://github.com/danilowoz/react-content-loader/pull/144/files

I think this is now more proper instead of assuming what the baseUrl should be for the applications we now have them pass it in.

I think this is a potential breaking change for applications so may want to make this a 3.0.0 version?
Will leave this up to you though.

Tested this in my companies application and it all now works properly.

Let me know if need anything further.