### PR TITLE
perf(content-loader): avoid function call in html ng template syntax

### DIFF
--- a/projects/netbasal/ngx-content-loader/src/lib/content-loader.component.ts
+++ b/projects/netbasal/ngx-content-loader/src/lib/content-loader.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 
 function uid() {
   return Math.random()
@@ -10,7 +10,7 @@ function uid() {
   selector: 'content-loader',
   templateUrl: './content-loader.component.html'
 })
-export class ContentLoaderComponent implements OnInit {
+export class ContentLoaderComponent implements OnInit, OnChanges {
   @Input()
   animate = true;
   @Input()
@@ -44,17 +44,29 @@ export class ContentLoaderComponent implements OnInit {
   rtlAnimation = ['1; -3', '2; -2', '3; -1'];
   animationValues;
 
+  fillStyle: { fill: string };
+  clipStyle: string;
+
   ngOnInit() {
     this.animationValues = this.rtl ? this.rtlAnimation : this.defautlAnimation;
+    this.setFillStyle();
+    this.setClipStyle();
   }
 
-  get fillStyle() {
-    return {
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['baseUrl'].previousValue !== changes['baseUrl'].currentValue) {
+      this.setFillStyle();
+      this.setClipStyle();
+    }
+  }
+
+  setFillStyle() {
+    this.fillStyle = {
       fill: `url(${this.baseUrl}#${this.idGradient})`
     };
   }
 
-  get clipStyle() {
-    return `url(${this.baseUrl}#${this.idClip})`;
+  setClipStyle() {
+    this.clipStyle = `url(${this.baseUrl}#${this.idClip})`;
   }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7777929/63205092-6b78e780-c0da-11e9-93e7-84f226a91589.png)

When i check how many times clipStyle function call occur, i found that it was called every change detection timing.
![image](https://user-images.githubusercontent.com/7777929/63205104-982cff00-c0da-11e9-96f9-fce295f53c03.png)

It means `[attr.clip-path]="clipStyle" [ngStyle]="fillStyle"` can't know when clipStyle, fillStyle value changed (because fillStyle, clipStyle was function)

It should call one time for one component. and it should call when baseUrl value changed

So i define setFillStyle, setClipStyle function and call it when ngOnInit, ngOnChanges.
